### PR TITLE
Correct Text Domain

### DIFF
--- a/clarity-ad-blocker.php
+++ b/clarity-ad-blocker.php
@@ -9,7 +9,7 @@
  * Requires at least: 5.0
  * Tested up to: 5.9
  * Requires PHP: 7.0
- * Text Domain: wp-clarity
+ * Text Domain: clarity-ad-blocker
  * Domain Path: /languages/
  * License:     GPL v2 or later
  */


### PR DESCRIPTION
This plugin's slug is `clarity-ad-blocker`, but the current Text Domain is set as `wp-clarity`. Make sure it is equal to your plugin slug. Please refer to [https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains).